### PR TITLE
Fix Hardcoded Email Address

### DIFF
--- a/src/app/export/export.page.ts
+++ b/src/app/export/export.page.ts
@@ -63,7 +63,7 @@ export class ExportPage implements OnInit {
   
       }else if(this.exportOptions.target == "email_pact"){
         //download and attach to email with preconfigured message
-        this.shareToEmail("pact-data@example.org");
+        this.shareToEmail("pactdatasets@gmail.com");
   
       }else if(this.exportOptions.target == "email_custom"){
         //download and attach to email no dest


### PR DESCRIPTION
The original source contains the wrong email address for automatic submissions to the PACT Data Collaboration site. The destination should be "pactdatasets@gmail.com," as listed on the PACT Data Collaboration site documentation:
https://mitll.github.io/PACT/datasets.html

